### PR TITLE
Update devicePixelRatio in onMetricsChanged

### DIFF
--- a/lib/flutter_device_type.dart
+++ b/lib/flutter_device_type.dart
@@ -32,6 +32,7 @@ class Device {
       ui.window.onMetricsChanged = () {
         _device = null;
 
+        devicePixelRatio = ui.window.devicePixelRatio;
         size = ui.window.physicalSize;
         width = size.width;
         height = size.height;


### PR DESCRIPTION
Previously the devicePixelRatio was only set once at initialization, when it possibly was not available yet. This could lead to a wrong device type detection (e.g. a OnePlus Nord was reliably detected to be a tablet when running a Flutter app in release mode). Since the devicePixelRatio can change with an onMetricsChanged call, update the static devicePixelRatio variable in that callback to fix the device type detection.